### PR TITLE
[docs] Update git checkout url to new lantzdev

### DIFF
--- a/docs/contributing-core.rst
+++ b/docs/contributing-core.rst
@@ -40,7 +40,12 @@ and in Windows::
 
 and then install an editable package from `Lantz at Github`_::
 
-    $ pip install -e git+git://github.com/hgrecco/lantz.git#egg=lantz
+    $ pip install -U git+git://github.com/lantzproject/lantz-core.git#egg=lantz-core
+    $ pip install -U git+git://github.com/lantzproject/lantz-drivers.git#egg=lantz-drivers
+    $ pip install -U git+git://github.com/lantzproject/lantz-qt.git#egg=lantz-qt
+    $ pip install -U git+git://github.com/lantzproject/lantz-sims.git#egg=lantz-sims
+    $ pip install -U git+git://github.com/lantzproject/lantz-ino.git#egg=lantz-ino
+    $ pip install -U git+git://github.com/lantzproject/lantz.git#egg=lantz-git
 
 You will find the code in `~/lantzenv/src/lantz` (OSX/Linux) or
 `%USERPROFILE%\\Desktop\\lantzenv\\src\\lantz` (Windows).


### PR DESCRIPTION
Update git url after lantz 0.4-dev was split into self-contained modules.
github.com/hgrecco/lantz.git -> github.com/lantzproject/lantz-*.git

(installing lantz-qt and lantz-ino packages are optional, but most devs won't mind checking out the whole project).